### PR TITLE
Add ssh key handling

### DIFF
--- a/fast-vm
+++ b/fast-vm
@@ -162,13 +162,18 @@ handle_multiple_requests () {
 	operation="$1"
 	# VM number is in other position in 'create' operation, change the operation so we don't loose the image_name
 	if [ "$operation" == 'create' ]; then operation="$operation $2"; fi
+	if [ "$operation" == 'scp' ] || [ "$operation" == "keydist" ]; then SERIALIZE=1; fi
 	# get the rest of the command line for calling it later
 	original_arguments=$(echo "$@"|sed -e "s/$operation $vm_number//")
 	pmsg $P_DEBUG "Starting to handle multiple operations\n"
 	all_pids=''
 	for vm in $vm_number; do
 		pmsg $P_DEBUG "Calling operation: ./fast-vm $operation $vm $original_arguments\n"
-		MULTI_OPERATION=1 $fast_vm_bin $operation $vm $original_arguments &
+		if [ -z "$SERIALIZE" ]; then
+			MULTI_OPERATION=1 $fast_vm_bin $operation $vm $original_arguments &
+		else
+			MULTI_OPERATION=1 $fast_vm_bin $operation $vm $original_arguments
+		fi
 		all_pids="$all_pids $!"
 	done
 	errors=0
@@ -258,6 +263,12 @@ usage () {
 		ssh)
 			echo "$0 ssh <VmNumber|'VmNumber1 VmNumber2 ...'> [/path/to/custom/script]"
 			;;
+		scp)
+			echo "$0 scp <VmNumber|'VmNumber1 VmNumber2 ...'> vm:/remote/sourcefile|/local/sourcefile /local/destfile|vm:/remote/destfile"
+			;;
+		keydist)
+			echo "$0 keydist <VmNumber|'VmNumber1 VmNumber2 ...'>"
+			;;
 		delete)
 			echo "$0 delete <VmNumber|'VmNumber1 VmNumber2 ...'> [PathToDeleteHackFile]"
 			;;
@@ -276,7 +287,7 @@ usage () {
 		*)
 			echo "== fast-vm version 1.3 <ofamera@redhat.com> =="
 			echo "$0 <action> <options>"
-			for cmd in import_image import_custom_image export_image remove_image resize_image import_profile remove_profile list_images create delete edit_note resize info list start stop console ssh;
+			for cmd in import_image import_custom_image export_image remove_image resize_image import_profile remove_profile list_images create delete edit_note resize info list start stop console keydist ssh scp;
 			do
 				usage $cmd noexit
 			done
@@ -910,7 +921,7 @@ case "$1" in
 						if [ ! -z "$4" ] && [ -x "$4" ]; then
 							eval "$4 192.168.$SUBNET_NUMBER.$vm_number" | sed -e "s/^/\[$vmn\]/"
 						else
-							ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "root@192.168.$SUBNET_NUMBER.$vm_number"
+							ssh -i "$FASTVM_USER_CONF_DIR/id_fastvm.pub" -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "root@192.168.$SUBNET_NUMBER.$vm_number"
 						fi
 					fi
 				;;
@@ -966,8 +977,43 @@ case "$1" in
 				pmsg $P_ERROR "$3 not executable\n" $vm_number
 			fi
 		else
-			ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "root@192.168.$SUBNET_NUMBER.$vm_number"
+			ssh -i $FASTVM_USER_CONF_DIR/id_fastvm -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "root@192.168.$SUBNET_NUMBER.$vm_number"
 		fi
+		;;
+	scp)
+		vm_number="$2"
+		if [ -z "$vm_number" ]; then pmsg $P_ERROR "VM number missing\n"; usage scp; fi
+		if [[ $vm_number = *[\ ]* ]]; then handle_multiple_requests $@;	fi
+		check_vm_number "$vm_number" "inactive"
+		update_access_time "$vm_number"
+
+		if [ -z "$4" ]; then
+			pmsg $P_ERROR "scp requires a sourcepath and destination path to copy\n" $vm_number
+			exit 1
+		fi
+
+		wait_for_ssh "$vm_number"
+		sourcepath=$(echo "$3" | sed "s/\(.*\)\bvm:\(.*\)/\1root@192.168.$SUBNET_NUMBER.$vm_number:\2/")
+		destpath=$(echo "$4" | sed "s/\(.*\)\bvm:\(.*\)/\1root@192.168.$SUBNET_NUMBER.$vm_number:\2/")
+		scp -i $FASTVM_USER_CONF_DIR/id_fastvm -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$sourcepath" "$destpath"
+		;;
+	keydist)
+		vm_number="$2"
+		if [ -z "$vm_number" ]; then pmsg $P_ERROR "VM number missing\n"; usage keydist; fi
+		if [[ $vm_number = *[\ ]* ]]; then handle_multiple_requests $@;	fi
+
+		check_vm_number "$vm_number" "inactive"
+		update_access_time "$vm_number"
+
+		if [ ! -f "$FASTVM_USER_CONF_DIR/id_fastvm" ]; then
+			pmsg $P_WARNING "Generating new ssh key with empty passphrase for fast-vm use at $FASTVM_USER_CONF_DIR/id_fastvm\n" $vm_number
+			ssh-keygen -P '' -f $FASTVM_USER_CONF_DIR/id_fastvm
+		fi
+
+		wait_for_ssh "$vm_number"
+		ssh-copy-id -i "$FASTVM_USER_CONF_DIR/id_fastvm" \
+			-o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+			"root@192.168.$SUBNET_NUMBER.$vm_number" | egrep '(password|Now try logging into the machine)' | sed "s@with:.*@with: $0 ssh $vm_number@"
 		;;
 	console)
 		vm_number="$2"

--- a/man/fast-vm.8
+++ b/man/fast-vm.8
@@ -106,9 +106,18 @@ fast-vm \(em script for defining VMs from images provided in thin LVM pool
 .BI "console " VmNumber
 
 .B fast-vm
+.B keydist
+.RI < VmNumber | "'VmNumber1 VmNumber2 ...'" >
+
+.B fast-vm
 .B ssh
 .RI < VmNumber | "'VmNumber1 VmNumber2 ...'" >
 .RI [ /path/to/custom/script ]
+
+.B fast-vm
+.B scp
+.RI < VmNumber | "'VmNumber1 VmNumber2 ...'" >
+.RI < "vm:/remote/sourcefile /local/destfile" | "/local/sourcefile vm:/remote/destfile" >
 
 .SH DESCRIPTION
 fast-vm is provides command-line interface to create virtual machines (VMs) in 
@@ -181,6 +190,24 @@ Number identifying the VM. Currently limited to range 20-220 to allow to be used
 .TP
 .I /path/to/custom/script
 Local path to script which will be executed as soon as the VM is started and reachable by SSH via its IP address assigned by DHCP.
+
+.TP
+.I vm:/remote/sourcefile|/local/sourcefile
+Path to the source file to be copied via SCP.
+Can be local to the fast-vm host or remote, on a guest VM.
+Use the literal hostname 
+.I vm
+to denote that the file should be copied from the specified vm.
+fast-vm will replace 'vm:' with the correct guest hostname.
+
+.TP
+.I /local/destfile|vm:/remote/destfile
+Path to the destination file to be written to, via SCP.
+Can be local to the fast-vm host or remote, on a guest VM.
+Use the literal hostname
+.I vm
+to denote that the file should be copied to the specified vm.
+fast-vm will replace 'vm:' with the correct guest hostname.
 
 .SH TEMPLATE MACROS
 In the libvirt XML and hack files you variables from 
@@ -329,6 +356,14 @@ Create machine with custom definition and hack file. Start it and after it's SSH
 .RB "Create VMs with numbers 43, 44, 45 using the " "6.7" " image with single command."
 .sp
 .BI "fast-vm create " "6.7 '43 44 45'"
+
+.RB "Automatically create an ssh key if it doesn't already exist and distribute it to VMs 41 and 42"
+.sp
+.BI "fast-vm keydist " "'41 42'"
+
+.RB "scp a script to VMs 41 and 42. By default this goes in root's home directory, or specify a path instead"
+.sp
+.BI "fast-vm scp " "'41 42' script.sh vm:"
 
 .SH EXIT CODES
 In case of error the fast-vm will return non-zero exit code. When multiple VMs were specified then zero exit code is returned only when operation succeeded on all VMs. If any of VMs reported non-zero exit code, then the overal exit code will also be non-zero.


### PR DESCRIPTION
Thank you for fast-vm!  I've come to use it nearly every day now.  There are two features I've wanted for some time and I've attempted to implement them here:  simplifying the creation of a separate ssh key, solely for fast-vm's use (for passwordless logins) and the ability to scp files easily.

* fast-vm keygen
Generate a passphraseless ssh key for fast-vm's use.  Stored in $FASTVM_USER_CONF_DIR

* fast-vm keydist <VmNumber|'VmNumber1 VmNumber2 ...'>
Distribute the fast-vm ssh key (using ssh-copy-id) to one or more VMs

* fast-vm scp <VmNumber|'VmNumber1 VmNumber2 ...'> /path/to/source/on/this/host [/path/on/destination/to/put/it]
Provide an easy way to scp files from the host to guest VMs, using the ssh key if it exists

* fast-vm ssh changes to utilize the fast-vm ssh key if it exists