### PR TITLE
Fix scp with multiple file paths

### DIFF
--- a/fast-vm
+++ b/fast-vm
@@ -1002,9 +1002,9 @@ case "$1" in
 		fi
 
 		wait_for_ssh "$vm_number"
-		sourcepath=$(echo "$3" | sed "s/\(.*\)\bvm:\(.*\)/\1root@192.168.$SUBNET_NUMBER.$vm_number:\2/")
-		destpath=$(echo "$4" | sed "s/\(.*\)\bvm:\(.*\)/\1root@192.168.$SUBNET_NUMBER.$vm_number:\2/")
-		scp -i $FASTVM_USER_CONF_DIR/id_fastvm -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$sourcepath" "$destpath"
+		shift 2
+		arguments=$(echo "$@"|sed "s/\bvm:/root@192.168.$SUBNET_NUMBER.$vm_number:/g")
+		scp -i $FASTVM_USER_CONF_DIR/id_fastvm -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $arguments
 		;;
 	keydist)
 		vm_number="$2"


### PR DESCRIPTION
Hi,

After a bit more use I've found myself trying commands like `fast-vm scp 71 Downloads/*.rpm vm:` and that currently fails to copy.  It returns quickly, having copied nothing.

This PR loops through the filenames, transforming "vm:" if found.  I can now successfully scp multiple files to and from one or multiple VMs.  Comments welcome, and thanks in advance!